### PR TITLE
Expose query start time metrics

### DIFF
--- a/protector/protector_main.py
+++ b/protector/protector_main.py
@@ -60,6 +60,9 @@ class Protector(object):
         self.DATAPOINTS_SERVED_COUNT = Counter('datapoints_served_count', 'datapoints served count')
         self.TSDB_REQUEST_LATENCY = Histogram('tsdb_request_latency_seconds', 'OpenTSDB Requests latency histogram', ['http_code', 'path', 'method'])
 
+        # Prometheus histogram based on query start time age in days
+        self.TSDB_REQUEST_INTERVAL = Histogram('tsdb_request_interval', 'OpenTSDB Requests interval based on query start time', ['interval'],buckets=(1,30,90))
+
     def check(self, query):
 
         logging.debug("Checking OpenTSDBQuery: {}".format(query.get_id()))


### PR DESCRIPTION
## Description

To help identify patterns and trends in query performance and execution, I have implemented multiple new Prometheus metrics that capture query start date information. These metrics count the age of the query start date and provide four options: less than 1 day, 1 month, 3 months, and more than 3 months.

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.