### PR TITLE
Added default log rotate

### DIFF
--- a/config_sample.yaml
+++ b/config_sample.yaml
@@ -36,3 +36,7 @@ blockedlist:
 # Queries matching these patterns will skip the filters (if not rejected by the blockedlist!)
 allowedlist:
   - test\.e2e\.
+log:
+  rotate: True
+  maxBytes: 500000000
+  backupCount: 2

--- a/protector/config/default_config.py
+++ b/protector/config/default_config.py
@@ -43,4 +43,9 @@ DEFAULT_CONFIG = {
     'c': None,
     'verbose': 0,
     'v': 0,
+    'log' : {
+        'rotate': True,
+        'maxBytes': 256000000,
+        'backupCount': 2
+    }
 }

--- a/protector/config/loader.py
+++ b/protector/config/loader.py
@@ -39,6 +39,16 @@ def load_config():
     # Parameters from commandline take precedence over all others
     config = overwrite_config(config, cli_config)
 
+    if "log" not in config:
+        config.update({
+            "log": default_config.DEFAULT_CONFIG["log"]
+        })
+    elif "log" in config and config["log"]["rotate"]:
+        if "maxBytes" not in config["log"] or "backupCount" not in config["log"]:
+            config.update({
+                "log": default_config.DEFAULT_CONFIG["log"]
+            })
+
     # Set verbosity level
     if 'verbose' in config:
         if config['verbose'] == 1:

--- a/protector/daemon.py
+++ b/protector/daemon.py
@@ -11,6 +11,8 @@
 #
 
 import logging
+import logging.handlers as handlers
+
 import sys
 
 from protector.proxy import server
@@ -42,7 +44,11 @@ class ProtectorDaemon(object):
             logging.info("Starting in foreground...")
 
     def configure_logging(self):
-        logging.getLogger('').handlers = []
+        if self.config.log["rotate"]:
+            logHandler = handlers.RotatingFileHandler(self.config.logfile, maxBytes=self.config.log["maxBytes"], backupCount=self.config.log["backupCount"])
+            logging.getLogger('').handlers = [logHandler]
+        else:
+            logging.getLogger('').handlers = []
         logging_config = {
             "level": logging.DEBUG,
             "format": '%(asctime)s [%(levelname)s] %(message)s'


### PR DESCRIPTION

## Description

I have added log rotation functionality. By default, the maximum file size is set to 256 megabytes, and two backup files are kept. These default values can be overwritten in the config file to suit your specific needs.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.